### PR TITLE
Extended exception message for `expect(...).to.exist;`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 chai-files changelog
 ==============================================================================
 
+## v1.4.0
+
+- extended exception messages for `expect(...).to.exist`
+
+
 ## v1.3.0
 
 - `expect(...).to.equal(file(...))`

--- a/src/dir-helper.js
+++ b/src/dir-helper.js
@@ -2,6 +2,8 @@ var fs = require('fs');
 var path = require('path');
 var AssertionError = require('assertion-error');
 
+var existsMessage = require('./exists-message');
+
 function DirectoryHelper(path) {
   this.path = path;
   this._exists = null;
@@ -52,7 +54,7 @@ Object.defineProperty(DirectoryHelper.prototype, 'isEmpty', {
 
 DirectoryHelper.prototype.assertExists = function(ssf) {
   if (!this.exists) {
-    throw new AssertionError('expected "' + this.path + '" to exist', {}, ssf);
+    throw new AssertionError(existsMessage(this.path), {}, ssf);
   } else if (!this.stats.isDirectory()) {
     throw new AssertionError('expected "' + this.path + '" to be a directory', {}, ssf);
   }

--- a/src/exists-message.js
+++ b/src/exists-message.js
@@ -1,0 +1,49 @@
+var path = require('path');
+
+var MAX_FILE_LIST_LENGTH = 20;
+
+function existsMessage(_path) {
+  var file = require('./file-helper').file;
+  var dir = require('./dir-helper').dir;
+
+  var message = '';
+
+  function checkParent(_path) {
+    var parentPath = path.dirname(_path);
+    if (parentPath === '.') { return; }
+
+    var d = dir(parentPath);
+    if (!d.exists) {
+      message += 'parent path "' + parentPath + '" does not exist.\n';
+
+      if (parentPath !== '/') {
+        checkParent(parentPath);
+      }
+    } else if (!d.stats.isDirectory()) {
+      message += 'parent path "' + parentPath + '" exists and is a file.\n';
+
+    } else {
+      message += 'parent path "' + parentPath + '" exists and contains:\n';
+
+      d.content.slice(0, MAX_FILE_LIST_LENGTH).forEach(function(child) {
+        var f = file(path.join(parentPath, child));
+        message += '- ' + child + (f.stats.isDirectory() ? '/' : '') + '\n';
+      });
+
+      if (d.content.length > MAX_FILE_LIST_LENGTH) {
+        message += '- [' + (d.content.length - MAX_FILE_LIST_LENGTH) + ' more...]';
+      }
+    }
+  }
+
+  checkParent(_path);
+
+  var prefix = 'expected "' + _path + '" to exist';
+  if (message) {
+    prefix += '\n\n' + message.trim();
+  }
+
+  return prefix;
+}
+
+module.exports = existsMessage;

--- a/src/file-helper.js
+++ b/src/file-helper.js
@@ -2,9 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var AssertionError = require('assertion-error');
 
-var dir = require('./dir-helper').dir;
-
-var MAX_FILE_LIST_LENGTH = 20;
+var existsMessage = require('./exists-message');
 
 function FileHelper(path) {
   this.path = path;
@@ -56,44 +54,7 @@ Object.defineProperty(FileHelper.prototype, 'isEmpty', {
 
 FileHelper.prototype.assertExists = function(ssf) {
   if (!this.exists) {
-    var extended = '';
-
-    function checkParent(_path) {
-      var parentPath = path.dirname(_path);
-      if (parentPath === '.') { return; }
-
-      var d = dir(parentPath);
-      if (!d.exists) {
-        extended += 'parent path "' + parentPath + '" does not exist.\n';
-
-        if (parentPath !== '/') {
-          checkParent(parentPath);
-        }
-      } else if (!d.stats.isDirectory()) {
-        extended += 'parent path "' + parentPath + '" exists and is a file.\n';
-
-      } else {
-        extended += 'parent path "' + parentPath + '" exists and contains:\n';
-
-        d.content.slice(0, MAX_FILE_LIST_LENGTH).forEach(function(child) {
-          var f = file(path.join(parentPath, child));
-          extended += '- ' + child + (f.stats.isDirectory() ? '/' : '') + '\n';
-        });
-
-        if (d.content.length > MAX_FILE_LIST_LENGTH) {
-          extended += '- [' + (d.content.length - MAX_FILE_LIST_LENGTH) + ' more...]';
-        }
-      }
-    }
-
-    checkParent(this.path);
-
-    var message = 'expected "' + this.path + '" to exist';
-    if (extended) {
-      message += '\n\n' + extended.trim();
-    }
-
-    throw new AssertionError(message, {}, ssf);
+    throw new AssertionError(existsMessage(this.path), {}, ssf);
   } else if (!this.stats.isFile()) {
     throw new AssertionError('expected "' + this.path + '" to be a file', {}, ssf);
   }

--- a/src/file-helper.js
+++ b/src/file-helper.js
@@ -2,6 +2,10 @@ var fs = require('fs');
 var path = require('path');
 var AssertionError = require('assertion-error');
 
+var dir = require('./dir-helper').dir;
+
+var MAX_FILE_LIST_LENGTH = 20;
+
 function FileHelper(path) {
   this.path = path;
   this._exists = null;
@@ -52,7 +56,44 @@ Object.defineProperty(FileHelper.prototype, 'isEmpty', {
 
 FileHelper.prototype.assertExists = function(ssf) {
   if (!this.exists) {
-    throw new AssertionError('expected "' + this.path + '" to exist', {}, ssf);
+    var extended = '';
+
+    function checkParent(_path) {
+      var parentPath = path.dirname(_path);
+      if (parentPath === '.') { return; }
+
+      var d = dir(parentPath);
+      if (!d.exists) {
+        extended += 'parent path "' + parentPath + '" does not exist.\n';
+
+        if (parentPath !== '/') {
+          checkParent(parentPath);
+        }
+      } else if (!d.stats.isDirectory()) {
+        extended += 'parent path "' + parentPath + '" exists and is a file.\n';
+
+      } else {
+        extended += 'parent path "' + parentPath + '" exists and contains:\n';
+
+        d.content.slice(0, MAX_FILE_LIST_LENGTH).forEach(function(child) {
+          var f = file(path.join(parentPath, child));
+          extended += '- ' + child + (f.stats.isDirectory() ? '/' : '') + '\n';
+        });
+
+        if (d.content.length > MAX_FILE_LIST_LENGTH) {
+          extended += '- [' + (d.content.length - MAX_FILE_LIST_LENGTH) + ' more...]';
+        }
+      }
+    }
+
+    checkParent(this.path);
+
+    var message = 'expected "' + this.path + '" to exist';
+    if (extended) {
+      message += '\n\n' + extended.trim();
+    }
+
+    throw new AssertionError(message, {}, ssf);
   } else if (!this.stats.isFile()) {
     throw new AssertionError('expected "' + this.path + '" to be a file', {}, ssf);
   }

--- a/test/dir-test.js
+++ b/test/dir-test.js
@@ -39,7 +39,10 @@ describe('expect(dir(...))', function() {
       expect(function() {
         expect(dir('test/fixtures/missing')).to.exist;
       }).to.throw(function(err) {
-        expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing\" to exist');
+        expect(err.toString())
+          .to.match(/^AssertionError: expected "test\/fixtures\/missing" to exist/)
+          .to.contain('parent path "test/fixtures" exists and contains:\n');
+
         expect(err.showDiff).to.be.false;
         expect(err.actual).to.not.exist;
         expect(err.expected).to.not.exist;
@@ -85,7 +88,7 @@ describe('expect(dir(...))', function() {
       expect(function() {
         expect(dir('test/fixtures/missing')).to.be.empty;
       }).to.throw(function(err) {
-        expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing\" to exist');
+        expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing" to exist/);
         expect(err.showDiff).to.be.false;
         expect(err.actual).to.not.exist;
         expect(err.expected).to.not.exist;
@@ -113,7 +116,7 @@ describe('expect(dir(...))', function() {
       expect(function() {
         expect(dir('test/fixtures/missing')).to.not.be.empty;
       }).to.throw(function(err) {
-        expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing\" to exist');
+        expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing" to exist/);
         expect(err.showDiff).to.be.false;
         expect(err.actual).to.not.exist;
         expect(err.expected).to.not.exist;

--- a/test/file-test.js
+++ b/test/file-test.js
@@ -38,6 +38,17 @@ describe('expect(file(...))', function() {
         expect(err.expected).to.not.exist;
       });
     });
+
+    it('fails for missing parent folders', function() {
+      expect(function() {
+        expect(file('test/missing/missing.txt')).to.exist;
+      }).to.throw(function(err) {
+        expect(err.toString()).to.equal('AssertionError: expected \"test/missing/missing.txt\" to exist');
+        expect(err.showDiff).to.be.false;
+        expect(err.actual).to.not.exist;
+        expect(err.expected).to.not.exist;
+      });
+    });
   });
 
   describe('.to.not.exist', function() {

--- a/test/file-test.js
+++ b/test/file-test.js
@@ -32,7 +32,13 @@ describe('expect(file(...))', function() {
       expect(function() {
         expect(file('test/fixtures/missing.txt')).to.exist;
       }).to.throw(function(err) {
-        expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+        expect(err.toString())
+          .to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
+          .to.contain('parent path "test/fixtures" exists and contains:\n')
+          .to.contain('- bar.txt\n')
+          .to.contain('- empty/\n')
+          .to.contain('- empty.txt\n');
+
         expect(err.showDiff).to.be.false;
         expect(err.actual).to.not.exist;
         expect(err.expected).to.not.exist;
@@ -43,7 +49,40 @@ describe('expect(file(...))', function() {
       expect(function() {
         expect(file('test/missing/missing.txt')).to.exist;
       }).to.throw(function(err) {
-        expect(err.toString()).to.equal('AssertionError: expected \"test/missing/missing.txt\" to exist');
+        expect(err.toString())
+          .to.match(/^AssertionError: expected "test\/missing\/missing.txt" to exist/)
+          .to.contain('parent path "test/missing" does not exist.\n')
+          .to.contain('parent path "test" exists and contains:\n')
+          .to.contain('- fixtures/\n');
+
+        expect(err.showDiff).to.be.false;
+        expect(err.actual).to.not.exist;
+        expect(err.expected).to.not.exist;
+      });
+    });
+
+    it('fails for missing files if parent path is file', function() {
+      expect(function() {
+        expect(file('test/fixtures/bar.txt/foo.txt')).to.exist;
+      }).to.throw(function(err) {
+        expect(err.toString())
+          .to.match(/^AssertionError: expected "test\/fixtures\/bar.txt\/foo.txt" to exist/)
+          .to.contain('parent path "test/fixtures/bar.txt" exists and is a file.');
+
+        expect(err.showDiff).to.be.false;
+        expect(err.actual).to.not.exist;
+        expect(err.expected).to.not.exist;
+      });
+    });
+
+    it('fails for missing parent folders in absolute path', function() {
+      expect(function() {
+        expect(file('/tmp/missing/missing.txt')).to.exist;
+      }).to.throw(function(err) {
+        expect(err.toString())
+          .to.match(/^AssertionError: expected "\/tmp\/missing\/missing.txt" to exist/)
+          .to.contain('parent path "/tmp" exists and contains:\n');
+
         expect(err.showDiff).to.be.false;
         expect(err.actual).to.not.exist;
         expect(err.expected).to.not.exist;
@@ -91,7 +130,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/missing.txt')).to[method]('large solid object');
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -119,7 +158,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/foo.txt')).to[method](file('test/fixtures/baz.txt'));
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/baz.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/baz.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -128,7 +167,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/baz.txt')).to[method](file('test/fixtures/foo.txt'));
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/baz.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/baz.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -161,7 +200,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/missing.txt')).to.not[method]('small fixture file');
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -190,7 +229,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/foo.txt')).to.not[method](file('test/fixtures/baz.txt'));
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/baz.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/baz.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -199,7 +238,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/baz.txt')).to.not[method](file('test/fixtures/foo.txt'));
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/baz.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/baz.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -228,7 +267,7 @@ describe('expect(file(...))', function() {
       expect(function() {
         expect(file('test/fixtures/missing.txt')).to.be.empty;
       }).to.throw(function(err) {
-        expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+        expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
         expect(err.showDiff).to.be.false;
         expect(err.actual).to.not.exist;
         expect(err.expected).to.not.exist;
@@ -256,7 +295,7 @@ describe('expect(file(...))', function() {
       expect(function() {
         expect(file('test/fixtures/missing.txt')).to.not.be.empty;
       }).to.throw(function(err) {
-        expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+        expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
         expect(err.showDiff).to.be.false;
         expect(err.actual).to.not.exist;
         expect(err.expected).to.not.exist;
@@ -287,7 +326,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/missing.txt')).to[method]('large solid object');
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -319,7 +358,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/missing.txt')).to.not[method]('small fixture file');
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -351,7 +390,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/missing.txt')).to[method](/large.*object/);
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -383,7 +422,7 @@ describe('expect(file(...))', function() {
         expect(function() {
           expect(file('test/fixtures/missing.txt')).to.not[method](/small.*file/);
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -417,7 +456,7 @@ describe('expect(string)', function() {
         expect(function() {
           expect('large solid object').to[method](file('test/fixtures/missing.txt'));
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;
@@ -450,7 +489,7 @@ describe('expect(string)', function() {
         expect(function() {
           expect('small fixture file').to.not[method](file('test/fixtures/missing.txt'));
         }).to.throw(function(err) {
-          expect(err.toString()).to.equal('AssertionError: expected \"test/fixtures/missing.txt\" to exist');
+          expect(err.toString()).to.match(/^AssertionError: expected "test\/fixtures\/missing.txt" to exist/)
           expect(err.showDiff).to.be.false;
           expect(err.actual).to.not.exist;
           expect(err.expected).to.not.exist;

--- a/test/file-test.js
+++ b/test/file-test.js
@@ -77,11 +77,12 @@ describe('expect(file(...))', function() {
 
     it('fails for missing parent folders in absolute path', function() {
       expect(function() {
-        expect(file('/tmp/missing/missing.txt')).to.exist;
+        expect(file('/foobar/missing/missing.txt')).to.exist;
       }).to.throw(function(err) {
         expect(err.toString())
-          .to.match(/^AssertionError: expected "\/tmp\/missing\/missing.txt" to exist/)
-          .to.contain('parent path "/tmp" exists and contains:\n');
+          .to.match(/^AssertionError: expected "\/foobar\/missing\/missing.txt" to exist/)
+          .to.contain('parent path "/foobar" does not exist.\n')
+          .to.contain('parent path "/" exists and contains:\n');
 
         expect(err.showDiff).to.be.false;
         expect(err.actual).to.not.exist;


### PR DESCRIPTION
Example:

```
AssertionError: expected "test/missing/missing.txt" to exist

parent path "test/missing" does not exist.
parent path "test" exists and contains:
- dir-test.js
- file-test.js
- fixtures/
- helpers/
```

Resolves #10 

/cc @twokul
